### PR TITLE
Update schema files and add new fields to API - fixes #8

### DIFF
--- a/resources/schemas/ameax_receipt.v1-0.schema.json
+++ b/resources/schemas/ameax_receipt.v1-0.schema.json
@@ -88,6 +88,44 @@
         "required": ["description", "quantity", "price", "tax_rate", "tax_type"]
       }
     },
+    "document_pdf": {
+      "type": ["object", "null"],
+      "properties": {
+        "type": { 
+          "type": "string", 
+          "enum": ["base64", "url"],
+          "description": "Method of providing the PDF document"
+        },
+        "content": { 
+          "type": "string",
+          "description": "Base64 encoded PDF content (when type is 'base64')"
+        },
+        "url": { 
+          "type": "string",
+          "format": "uri",
+          "description": "HTTPS URL to download the PDF (when type is 'url')"
+        }
+      },
+      "required": ["type"],
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "base64" } }
+          },
+          "then": {
+            "required": ["content"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "url" } }
+          },
+          "then": {
+            "required": ["url"]
+          }
+        }
+      ]
+    },
     "custom_data": {
       "type": ["object", "null"],
       "additionalProperties": true

--- a/resources/schemas/ameax_sale.v1-0.schema.json
+++ b/resources/schemas/ameax_sale.v1-0.schema.json
@@ -77,9 +77,7 @@
       },
       "amount": {
         "type": "number",
-        "minimum": 0,
-        "multipleOf": 0.01,
-        "pattern": "^\\d+\\.\\d{2}$"
+        "minimum": 0
       },
       "probability": {
         "type": "integer",


### PR DESCRIPTION
## Summary
Resolves #8 by updating JSON schema files from ameax-json-schema project and identifying required API SDK extensions.

- Added `document_pdf` field to receipt schema enabling PDF attachment support via base64 encoding or HTTPS URLs
- Simplified amount validation in sale schema by removing strict decimal constraints
- Updated organization and private person account schemas with formatting improvements

## Changes Made
### Receipt Schema (`ameax_receipt.v1-0.schema.json`)
- **NEW**: `document_pdf` field with two modes:
  - `base64`: Include PDF content as base64 encoded string
  - `url`: Reference PDF via HTTPS URL
- Conditional validation ensures appropriate fields are required based on type

### Sale Schema (`ameax_sale.v1-0.schema.json`) 
- **SIMPLIFIED**: `amount` field validation now only requires `type: number` and `minimum: 0`
- **REMOVED**: Strict `multipleOf: 0.01` and `pattern: "^\\d+\\.\\d{2}$"` constraints

### Other Schemas
- Organization and private person account schemas updated with formatting consistency

## API SDK Extensions Required
The following extensions to the API SDK are identified based on schema changes:
- [ ] Create `DocumentPdf` model for PDF attachment support
- [ ] Add PDF document methods to `Receipt` model
- [ ] Update amount validation in `Sale` model

## Test Plan
- [ ] Validate updated schemas against existing data
- [ ] Test PDF document attachment functionality
- [ ] Verify amount field accepts various decimal formats
- [ ] Run existing test suite to ensure backward compatibility

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)